### PR TITLE
feat: introduce queue for storing laps

### DIFF
--- a/packages/backend/src/controllers/cli.controller.ts
+++ b/packages/backend/src/controllers/cli.controller.ts
@@ -2,7 +2,7 @@
 import readline from "readline";
 import { stdin as input, stdout as output } from "node:process";
 import { TeamService } from "../services/team.service";
-import { LapService } from "../services/laps.service";
+import { TelraamLapService } from "../services/telraamlaps.service";
 
 const commands = {
   fetchTeams: () => {
@@ -10,7 +10,7 @@ const commands = {
     return TeamService.getInstance().fetch();
   },
   syncLaps: () => {
-    return LapService.getInstance().syncMissingLaps();
+    return TelraamLapService.getInstance().syncMissingLaps();
   },
   help: () => {
     console.log("Available commands:");

--- a/packages/backend/src/controllers/teams.controller.ts
+++ b/packages/backend/src/controllers/teams.controller.ts
@@ -3,7 +3,7 @@ import { Lap } from "../models/lap.model";
 import { Team } from "../models/team.model";
 import { TeamsLapsAddRoute, TeamsLapsRoute, TeamsRoute } from "../types/team.types";
 import config from "../config";
-import { LapService } from "../services/laps.service";
+import { TelraamLapService } from "../services/telraamlaps.service";
 import { Between, Equal } from "typeorm";
 
 export default (server: FastifyInstance) => {

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -15,7 +15,7 @@ import { Socket } from "socket.io";
 import { TeamService } from "./services/team.service";
 import config from "./config";
 import { Token } from "./models/token.model";
-import { LapService } from "./services/laps.service";
+import { TelraamLapService } from "./services/telraamlaps.service";
 
 // Create a Fastify instance
 export const server = fastify({
@@ -101,7 +101,7 @@ async function start() {
     // Start team fetching
     TeamService.getInstance().fetch();
     // push the missing laps from SQLite to Telraam
-    LapService.getInstance().syncMissingLaps();
+    TelraamLapService.getInstance().syncMissingLaps();
   } catch (err) {
     server.log.error(err);
     process.exit(1);

--- a/packages/backend/src/services/lapsStore.service.ts
+++ b/packages/backend/src/services/lapsStore.service.ts
@@ -1,0 +1,59 @@
+import { Between, Equal } from "typeorm";
+import { server } from "../main";
+import { Lap } from "../models/lap.model";
+import { Team } from "../models/team.model";
+import config from "../config";
+import { TelraamLapService } from "./telraamlaps.service";
+
+class LapStoreService {
+  private queue: Laps.QueuedLap[] = []
+  private busy = false;
+  private async pushLap() {
+    const lapInfo = this.queue.shift();
+    if (!lapInfo) return;
+    const team = await Team.findOneBy({ id: lapInfo.teamId });
+    if (!team) {
+      server.log.warn(`A lap was scheduled for an unknown teamId: ${lapInfo.teamId}`)
+      return;
+    }
+
+    // Make sure the date difference between the last lap and the new one is
+    // at lease the LAP_MIN_DIFFERENCE value.
+    const interferingLap = await Lap.findOne({
+      where: {
+        team: Equal(team),
+        timestamp: Between(lapInfo.timestamp - config.LAP_MIN_DIFFERENCE, lapInfo.timestamp + config.LAP_MIN_DIFFERENCE)
+      }
+    });
+    if (interferingLap) {
+      server.log.info(`Skipped lap for ${lapInfo.teamId} because there was another lap counted in the diff interval`);
+      return;
+    }
+
+    // Create a new lap and append it to the team.
+    const lap = new Lap();
+    lap.team = team;
+    lap.timestamp = lapInfo.timestamp;
+
+    // Attempt to save the lap
+    await lap.save();
+
+    TelraamLapService.getInstance().queueLap(lap);
+  }
+
+  private async flushQueue() {
+    if (this.busy) return;
+    this.busy = true;
+    while (this.queue.length !== 0) {
+      await this.pushLap();
+    }
+    this.busy = false;
+  }
+
+  scheduleLap(lap: Laps.QueuedLap) {
+    this.queue.push(lap);
+    this.flushQueue();
+  }
+}
+
+export const lapStoreService = new LapStoreService();

--- a/packages/backend/src/services/team.service.ts
+++ b/packages/backend/src/services/team.service.ts
@@ -3,7 +3,7 @@ import { TelraamTeam } from "../types/team.types";
 import { Team } from "../models/team.model";
 import { AxiosService } from "./axios.service";
 import { server } from "../main";
-import { LapService } from "./laps.service";
+import { TelraamLapService } from "./telraamlaps.service";
 
 export class TeamService {
   // region SingleTon
@@ -162,7 +162,7 @@ export class TeamService {
       this.teamCache = response.data;
       await this.register();
       // We add a flush for our lap queue here because it's potentially faster than waiting for a push of another lap
-      LapService.getInstance().flush();
+      TelraamLapService.getInstance().flush();
     } catch (error: any) {
       return;
     }

--- a/packages/backend/src/services/telraamlaps.service.ts
+++ b/packages/backend/src/services/telraamlaps.service.ts
@@ -2,20 +2,20 @@ import { Lap } from "../models/lap.model";
 import { AxiosService } from "./axios.service";
 import { server } from "../main";
 
-export class LapService {
+export class TelraamLapService {
   // region SingleTon
-  private static Instance: LapService;
+  private static Instance: TelraamLapService;
 
-  public static getInstance(): LapService {
+  public static getInstance(): TelraamLapService {
     if (!this.Instance) {
-      this.Instance = new LapService();
+      this.Instance = new TelraamLapService();
     }
     return this.Instance;
   }
 
   // endregion
-  protected createInstance(): LapService {
-    return new LapService();
+  protected createInstance(): TelraamLapService {
+    return new TelraamLapService();
   }
 
   private queue: Lap[];

--- a/packages/backend/src/types/laps.d.ts
+++ b/packages/backend/src/types/laps.d.ts
@@ -1,0 +1,6 @@
+declare namespace Laps {
+  type QueuedLap = {
+    teamId: number;
+    timestamp: number;
+  }
+}


### PR DESCRIPTION
Introduces a queue where laps get pushed so they get pushed 1 by 1 to the DB.
This will prevent requests that are received around the same time to push both laps and add a duplicate lap in the DB.